### PR TITLE
Changed gitmodules from git: protocol to ssh:

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
 [submodule "sc3-plugins"]
     path = sc3-plugins
-    url = git://github.com/supercollider/sc3-plugins
+    url = git@github.com:supercollider/sc3-plugins
 [submodule "supercollider"]
     path = supercollider
-    url = git://github.com/supercollider/supercollider
+    url = git@github.com:supercollider/supercollider
 [submodule "libsndfile"]
     path = libsndfile
-    url = git://github.com/erikd/libsndfile
+    url = git@github.com:erikd/libsndfile


### PR DESCRIPTION
The git: protocol no longer works when trying to access repos held on github. This PR changes those to the ssh: protocol which allows access when doing:
```
git submodule init
git submodule update
```
or cloning the repo with the `--recurse-submodules` option